### PR TITLE
feat: Added a reusable H2 component

### DIFF
--- a/src/app/components/H2Title/H2Title.tsx
+++ b/src/app/components/H2Title/H2Title.tsx
@@ -1,0 +1,12 @@
+type Props = {
+    text: string,
+    size: string,
+}
+
+const H2Title = ({text, size = "72px"}: Props) => {
+    return (
+        <h2 style={{ fontSize: size }} className="text-black">{text}</h2>
+    )
+}
+
+export default H2Title;


### PR DESCRIPTION
Created a simple H2 reusable component that takes size in form of string.
If we need it to be 32px or 72px you just type <H2Title size="72px" text="Text goes here"/>

![image](https://github.com/user-attachments/assets/bb49f969-9de8-4cb5-8c29-dd8829d9b0e6)
![image](https://github.com/user-attachments/assets/85218169-f152-436d-ab6e-fcf668bea0b4)
![image](https://github.com/user-attachments/assets/eac3189e-2170-4544-bd7a-56ccc20776b8)
